### PR TITLE
Make bundle.js load from an absolute path (at /bundle.js)

### DIFF
--- a/components/Root.jsx
+++ b/components/Root.jsx
@@ -29,7 +29,7 @@ var Root = React.createClass({
             id='initial-props'
             type='application/json'
             dangerouslySetInnerHTML={initialProps} />
-          <script src='bundle.js' />
+          <script src='/bundle.js' />
         </body>
       </html>
     )


### PR DESCRIPTION
I was playing with react-static-site-boilerplate (actually the [ES6 version](https://github.com/oompt/react-static-boilerplate-ES6) by @oompt) and I found that if I added deeper routes (e.g. this commit astraw/react-static-boilerplate-ES6@36272b368118256ffed256467ed2b57b240b2660) , my pages were broken because `bundle.js` was not loaded. Adding a leading slash fixes this problem for me.

I'm definitely no JS/webpack/react-router/etc whiz, but this Works For Me. Still, I'm not sure if this breaks other stuff I don't know about.
